### PR TITLE
fixed tests for min and max

### DIFF
--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1870,12 +1870,12 @@ def test_mask(modin_df, pandas_df):
 def test_max(request, modin_df, pandas_df, axis, skipna, numeric_only):
     try:
         pandas_result = pandas_df.max(axis=axis, skipna=skipna, numeric_only=numeric_only)
+        modin_result = modin_df.max(axis=axis, skipna=skipna, numeric_only=numeric_only)
+        df_equals(modin_result, pandas_result)
     except:
         with pytest.raises(TypeError):
             modin_result = modin_df.max(axis=axis, skipna=skipna, numeric_only=numeric_only)
         return
-    modin_result = modin_df.max(axis=axis, skipna=skipna, numeric_only=numeric_only)
-    df_equals(modin_result, pandas_result)
 
 
 @pytest.mark.parametrize("modin_df, pandas_df", test_dfs_values, ids=test_dfs_keys)
@@ -2015,12 +2015,12 @@ def test_merge():
 def test_min(modin_df, pandas_df, axis, skipna, numeric_only):
     try:
         pandas_result = pandas_df.min(axis=axis, skipna=skipna, numeric_only=numeric_only)
+        modin_result = modin_df.min(axis=axis, skipna=skipna, numeric_only=numeric_only)
+        df_equals(modin_result, pandas_result)
     except:
         with pytest.raises(TypeError):
             modin_result = modin_df.min(axis=axis, skipna=skipna, numeric_only=numeric_only)
         return
-    modin_result = modin_df.min(axis=axis, skipna=skipna, numeric_only=numeric_only)
-    df_equals(modin_result, pandas_result)
 
 
 @pytest.mark.parametrize("modin_df, pandas_df", test_dfs_values, ids=test_dfs_keys)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1868,8 +1868,13 @@ def test_mask(modin_df, pandas_df):
     ids=arg_keys("numeric_only", bool_none_arg_keys),
 )
 def test_max(request, modin_df, pandas_df, axis, skipna, numeric_only):
+    try:
+        pandas_result = pandas_df.max(axis=axis, skipna=skipna, numeric_only=numeric_only)
+    except:
+        with pytest.raises(TypeError):
+            modin_result = modin_df.max(axis=axis, skipna=skipna, numeric_only=numeric_only)
+        return
     modin_result = modin_df.max(axis=axis, skipna=skipna, numeric_only=numeric_only)
-    pandas_result = pandas_df.max(axis=axis, skipna=skipna, numeric_only=numeric_only)
     df_equals(modin_result, pandas_result)
 
 
@@ -2008,8 +2013,13 @@ def test_merge():
     ids=arg_keys("numeric_only", bool_none_arg_keys),
 )
 def test_min(modin_df, pandas_df, axis, skipna, numeric_only):
+    try:
+        pandas_result = pandas_df.min(axis=axis, skipna=skipna, numeric_only=numeric_only)
+    except:
+        with pytest.raises(TypeError):
+            modin_result = modin_df.min(axis=axis, skipna=skipna, numeric_only=numeric_only)
+        return
     modin_result = modin_df.min(axis=axis, skipna=skipna, numeric_only=numeric_only)
-    pandas_result = pandas_df.min(axis=axis, skipna=skipna, numeric_only=numeric_only)
     df_equals(modin_result, pandas_result)
 
 


### PR DESCRIPTION
Tests for min and max should expect TypeError to be raised for invalid input combinations - this PR adds this to the tests.
